### PR TITLE
chore(deps): bump node via volta

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -76,6 +76,6 @@
     "reflect-metadata": "^0.2.2"
   },
   "volta": {
-    "node": "24.13.0"
+    "node": "24.13.1"
   }
 }


### PR DESCRIPTION
This PR isolates a node update from swc, which is blocking [another PR](https://github.com/bcgov/quickstart-aws-nosql/pull/165).